### PR TITLE
fix: build by pinning dependency

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -134,7 +134,7 @@
         "eslint": "^8.35.0",
         "eslint-plugin-vue": "^9.9.0",
         "prettier": "^2.8.4",
-        "sass": "^1.58.3",
+        "sass": "1.58.3",
         "sass-lint": "^1.13.1",
         "sass-loader": "^13.2.0",
         "typescript": "^4.9.5",

--- a/site/package.json
+++ b/site/package.json
@@ -147,7 +147,7 @@
     "eslint": "^8.35.0",
     "eslint-plugin-vue": "^9.9.0",
     "prettier": "^2.8.4",
-    "sass": "^1.58.3",
+    "sass": "1.58.3",
     "sass-lint": "^1.13.1",
     "sass-loader": "^13.2.0",
     "typescript": "^4.9.5",


### PR DESCRIPTION
De CI-build faalt sinds [run 31676703291](https://github.com/Informatievlaanderen/base-registries/actions/runs/31676703291/job/94377587101), in de site-containerbuild bij `RUN npm i`:

```
npm ERR! code EBADENGINE
npm ERR! notsup Not compatible with your version of node/npm: sass@1.102.0
npm ERR! notsup Required: {"node":">=20.19.0"}
npm ERR! notsup Actual:   {"npm":"9.5.0","node":"v18.15.0"}
```

## Waarom

`site/.dockerignore` sluit `./package-lock.json` uit, dus de lockfile komt de buildcontext niet binnen. In de container heeft `npm i` niets om op te pinnen en herresolvet hij `"sass": "^1.58.3"` naar de nieuwste match — vandaag `1.102.0`, en die laat Node 18 vallen. De build-stage draait op `node:18.15.0-alpine`.

Dit staat los van de laatste feature-commit: die raakt twee `.vue`-bestanden, een `launch.json` en een `.gitignore`, geen dependencies. Het was gewoon de eerste build ná de sass-release die Node 18 laat vallen; dezelfde build faalt vandaag ook zónder die commit.

## Wat deze PR doet

`sass` exact vastzetten op `1.58.3` in `site/package.json`, en dezelfde spec bijwerken in `site/package-lock.json` zodat beide overeenkomen. Een exacte spec overleeft wél in de container, ook zonder lockfile.

Nagekeken:

- `sass@1.58.3` heeft `engines: {node: ">=12.0.0"}` — in orde op Node 18. `sass@^1.58.3` resolvet vandaag tot `1.102.0`.
- Enkel `sass-loader` declareert sass nog, als peer `^1.3.0`; 1.58.3 voldoet, dus één kopie en geen geneste installatie.
- De nieuwste `sass-loader` binnen `^13.2.0` is 13.3.3 en peer't nog steeds `sass: ^1.3.0`, dus de pin botst niet met een nieuwere loader.

## Wat dit níét oplost

Alle 129 directe dependencies van de site zweven (`^`/`~`), geen enkele staat vast. Elke andere kan morgen op exact dezelfde manier de build breken, met een identiek foutbeeld.

De structurele oplossing is de lockfile níét uitsluiten en `npm i` vervangen door `npm ci`, zodat imagebuilds reproduceerbaar zijn. Dat is bewust niet meegenomen hier — deze PR deblokkeert enkel de build. `npm ci` is strenger over overeenstemming tussen `package.json` en lockfile, dus dat verdient een eigen wijziging waarin dat eerst geverifieerd wordt.
