### PR TITLE
ci: remove the confluence publish step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,8 +130,11 @@ jobs:
         SEMVER: ${{ env.RELEASE_VERSION }}
         WORKSPACE: ${{ github.workspace }}
 
+    # Mirrors the changelog to Confluence. The v1 content REST API this uses answers 404, so the step fails; the
+    # release itself is already done by the time it runs, so it may not take the build down with it.
     - name: Publish to Confluence
       if: env.RELEASE_VERSION != 'none'
+      continue-on-error: true
       shell: bash
       run: ./packages/Be.Vlaanderen.Basisregisters.Build.Pipeline/Content/ci-confluence.sh
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,27 +129,3 @@ jobs:
         BUILD_DOCKER_REGISTRY: ${{ secrets.VBR_DEVOPS_DOCKER_REGISTRY }}
         SEMVER: ${{ env.RELEASE_VERSION }}
         WORKSPACE: ${{ github.workspace }}
-
-    # Mirrors the changelog to Confluence. The v1 content REST API this uses answers 404, so the step fails; the
-    # release itself is already done by the time it runs, so it may not take the build down with it.
-    - name: Publish to Confluence
-      if: env.RELEASE_VERSION != 'none'
-      continue-on-error: true
-      shell: bash
-      run: ./packages/Be.Vlaanderen.Basisregisters.Build.Pipeline/Content/ci-confluence.sh
-      env:
-        CONFLUENCE_TITLE: ${{ env.REPOSITORY_NAME }}
-        CONFLUENCE_USERNAME: ${{ secrets.VBR_CONFLUENCE_USER }}
-        CONFLUENCE_PASSWORD: ${{ secrets.VBR_CONFLUENCE_PASSWORD }}
-
-  #  - name: Create Jira Release
-  #    if: env.RELEASE_VERSION != 'none'
-  #    shell: bash
-  #    run: ./packages/Be.Vlaanderen.Basisregisters.Build.Pipeline/Content/ci-jira.sh
-  #    env:
-  #      CONFLUENCE_TITLE: ${{ env.REPOSITORY_NAME }}
-  #      CONFLUENCE_USERNAME: ${{ secrets.VBR_CONFLUENCE_USER }}
-  #      CONFLUENCE_PASSWORD: ${{ secrets.VBR_CONFLUENCE_PASSWORD }}
-  #      JIRA_PREFIX: Site
-  #      JIRA_PROJECT: VBR
-  #      JIRA_VERSION: ${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
Verwijdert de stap **Publish to Confluence** uit `main.yml`, plus de al uitgecommentarieerde Jira-release ernaast — net zoals road-registry dat deed in `5fcae7be3 fix(pipeline): release pipeline remove confluence step`.

## Waarom

In [run 31681642168](https://github.com/Informatievlaanderen/base-registries/actions/runs/31681642168/job/94388192591) slaagde alles — semantic-release, versie, image push naar devops — en faalde enkel de laatste stap:

```
404 Client Error: Not Found for url:
https://vlaamseoverheid.atlassian.net/wiki/rest/api/content?title=base-registries&spaceKey=VBR&expand=version,ancestors
```

Dat is de **v1** content REST API van Confluence Cloud, die Atlassian aan het uitfaseren is ten voordele van v2. De release was op dat moment al rond: de stap draait ná `Push to devops`. Een groene build ging dus onderuit op een documentatiesync.

Bovenop de 404 breekt de foutafhandeling van het script zelf:

```python
except Exception as err:
    error = re.search('^404', err.message)   # AttributeError op python 3
```

`err.message` bestaat niet op een python 3 `HTTPError` (de runner draait 3.14.6), dus je krijgt een traceback in plaats van de bedoelde melding *"Page not found. Check the space key"*. Aan de uitkomst verandert dat niets — de `sys.exit(1)` staat buiten de `if`, dus de stap faalt sowieso op een 404 — het maakt enkel de oorzaak onleesbaar.

Beide zitten in `ci-md2conf.py`, dat uit het gedeelde `Be.Vlaanderen.Basisregisters.Build.Pipeline`-package komt en niet in deze repo staat. Vanuit hier valt er dus niets aan te repareren.

## Reikwijdte

De stap stond enkel in `main.yml`; `staging.yml`, `production.yml` en `test.yml` hebben hem niet. Na deze wijziging staat er geen enkele verwijzing naar Confluence meer in de workflows, en de `VBR_CONFLUENCE_*` secrets worden er niet meer gebruikt.

De uitgecommentarieerde Jira-release gaat mee, zoals daar ook: hij is dood en deelt dezelfde credentials.
