### PR TITLE
ci: show the deployed version in the CD run title

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,4 +1,5 @@
-name: CD New Production
+name: CD Production
+run-name: "CD Production: ${{ github.event.inputs.version }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,4 +1,5 @@
 name: CD Staging
+run-name: "CD Staging: ${{ github.event.inputs.version }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,5 @@
 name: CD Test
+run-name: "CD Test: ${{ github.event.inputs.version }}"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
De drie CD-workflows worden met de hand gestart met een versie als input, maar elke run heette gewoon `CD Test` / `CD Staging` / `CD New Production`. In het overzicht zag je dus niet welke versie waar naartoe ging zonder een run open te klikken.

`run-name` toegevoegd, zoals road-registry dat doet op zijn deploy-workflows:

```yaml
name: CD Test
run-name: "CD Test: ${{ github.event.inputs.version }}"
```

| workflow | titel van de run |
| --- | --- |
| `test.yml` | `CD Test: 2.21.0` |
| `staging.yml` | `CD Staging: 2.21.0` |
| `production.yml` | `CD Production: 2.21.0` |

## Hernoeming

De productieworkflow heette `CD New Production`, wat ze al een tijd niet meer is. Die wordt `CD Production`, zowel in de workflownaam als in de titel van de run. Er stonden geen andere verwijzingen naar de oude naam in de repo.

Let op: GitHub toont workflows in de Actions-zijbalk op naam, dus die staat na het mergen onder `CD Production`. Bestaande runs behouden hun oude titel; enkel nieuwe runs krijgen de nieuwe.

## Verder

`github.event.inputs.version` is dezelfde expressie die deze workflows al gebruiken in hun `with:`-blok, dus er komt geen nieuwe input bij en er verandert niets aan wat er gedeployed wordt. `main.yml` blijft ongemoeid: dat is de build, geen deploy.
